### PR TITLE
fix(ci): skip compiler tests when latexmk is not installed

### DIFF
--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -1,6 +1,15 @@
 """Tests for the LaTeX compiler service."""
 
+import shutil
+
+import pytest
+
 from compiler.compiler import _parse_errors, compile_latex
+
+requires_latexmk = pytest.mark.skipif(
+    shutil.which("latexmk") is None,
+    reason="latexmk not installed",
+)
 
 
 class TestParseErrors:
@@ -39,6 +48,7 @@ class TestParseErrors:
         assert _parse_errors("") == []
 
 
+@requires_latexmk
 class TestCompileLatex:
     def test_valid_document(self, tmp_path):
         latex = "\\documentclass{article}\n\\begin{document}\nHello $x^2$.\n\\end{document}\n"


### PR DESCRIPTION
## Summary
- CI was failing because the GitHub Actions runner doesn't have `latexmk` installed, causing all 3 `TestCompileLatex` integration tests to fail with `FileNotFoundError`
- Added `@pytest.mark.skipif` on `TestCompileLatex` so these tests are skipped when `latexmk` isn't on `PATH`
- The 22 pure-Python tests (`TestParseErrors`, agent tests) still run in CI; compiler integration tests run locally and in Docker where TeX is installed

Closes #7

## Test plan
- [x] CI passes on this branch (3 compiler tests skipped, 22 passed)
- [x] Tests still pass locally with latexmk installed (all 25 passed)