### PR TITLE
fix: env var overrides ignored for max_retries and dpi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
 # Project Commands
 
 Use the Makefile for project-specific commands (tests, linting, formatting, etc.) whenever possible. If the Makefile target doesn't fit the exact need, read the Makefile first to understand the standard tooling and environment setup (e.g., `uv run`, `PYTHONPATH=`), then construct commands accordingly.
+
+# Commit and PR Conventions
+
+- Use conventional commits (e.g., `fix:`, `feat:`, `chore:`, `docs:`)
+- Never include `Co-Authored-By` or any Claude/AI attribution in commits
+- Never include `Closes #N` or `Fixes #N` in commit messages — only in PR descriptions

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,6 +22,8 @@ export async function createJob(
     api_key?: string;
     max_retries?: number;
     dpi?: number;
+    temperature?: number;
+    max_tokens?: number;
     preamble?: string;
   },
 ): Promise<JobResponse> {

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -6,6 +6,10 @@ export interface AppSettings {
   useCustomModel: boolean;
   apiKey: string;
   preamble: string;
+  maxRetries: number | null;
+  dpi: number | null;
+  temperature: number | null;
+  maxTokens: number | null;
 }
 
 const DEFAULTS: AppSettings = {
@@ -14,6 +18,10 @@ const DEFAULTS: AppSettings = {
   useCustomModel: false,
   apiKey: "",
   preamble: "",
+  maxRetries: null,
+  dpi: null,
+  temperature: null,
+  maxTokens: null,
 };
 
 export function loadSettings(): AppSettings {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -125,6 +125,10 @@ export function HomePage() {
         model: model || undefined,
         api_key: settings.apiKey || undefined,
         preamble: settings.preamble || undefined,
+        max_retries: settings.maxRetries ?? undefined,
+        dpi: settings.dpi ?? undefined,
+        temperature: settings.temperature ?? undefined,
+        max_tokens: settings.maxTokens ?? undefined,
       });
       navigate(`/jobs/${res.job_id}`);
     } catch (err) {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, ExternalLink, RotateCcw } from "lucide-react";
+import { ArrowLeft, ExternalLink, RotateCcw, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -203,6 +203,112 @@ export function SettingsPage() {
               styles.
             </p>
           </div>
+
+          <Separator />
+
+          {/* Advanced settings */}
+          <details className="group">
+            <summary className="flex cursor-pointer items-center gap-2 text-sm font-medium list-none">
+              <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+              Advanced
+            </summary>
+            <div className="mt-4 space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <Label htmlFor="max-retries" className="text-sm">
+                    Max Retries
+                  </Label>
+                  <Input
+                    id="max-retries"
+                    type="number"
+                    min={0}
+                    placeholder="3"
+                    value={settings.maxRetries ?? ""}
+                    onChange={(e) =>
+                      update({
+                        maxRetries: e.target.value
+                          ? Number(e.target.value)
+                          : null,
+                      })
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Fix attempts per page
+                  </p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="dpi" className="text-sm">
+                    DPI
+                  </Label>
+                  <Input
+                    id="dpi"
+                    type="number"
+                    min={72}
+                    placeholder="300"
+                    value={settings.dpi ?? ""}
+                    onChange={(e) =>
+                      update({
+                        dpi: e.target.value ? Number(e.target.value) : null,
+                      })
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    PDF rasterization resolution
+                  </p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="temperature" className="text-sm">
+                    Temperature
+                  </Label>
+                  <Input
+                    id="temperature"
+                    type="number"
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    placeholder="0.1"
+                    value={settings.temperature ?? ""}
+                    onChange={(e) =>
+                      update({
+                        temperature: e.target.value
+                          ? Number(e.target.value)
+                          : null,
+                      })
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    LLM sampling temperature
+                  </p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="max-tokens" className="text-sm">
+                    Max Tokens
+                  </Label>
+                  <Input
+                    id="max-tokens"
+                    type="number"
+                    min={1}
+                    placeholder="16384"
+                    value={settings.maxTokens ?? ""}
+                    onChange={(e) =>
+                      update({
+                        maxTokens: e.target.value
+                          ? Number(e.target.value)
+                          : null,
+                      })
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Max tokens per LLM call
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Leave blank to use server defaults. These can also be set via
+                environment variables with the <code>NOTES2LATEX_</code> prefix.
+              </p>
+            </div>
+          </details>
 
           <Separator />
 

--- a/src/api/v1/agent/models.py
+++ b/src/api/v1/agent/models.py
@@ -10,8 +10,10 @@ from db.models import JobStatus
 class ConvertRequest(BaseModel):
     model: str = "openrouter/google/gemini-3-flash-preview"
     api_key: str | None = None
-    max_retries: int = 3
-    dpi: int = 300
+    max_retries: int | None = None
+    dpi: int | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
     preamble: str | None = None
 
 

--- a/src/api/v1/agent/routes.py
+++ b/src/api/v1/agent/routes.py
@@ -115,6 +115,8 @@ async def create_job(
         api_key=req.api_key,
         max_retries=req.max_retries,
         dpi=req.dpi,
+        temperature=req.temperature,
+        max_tokens=req.max_tokens,
         preamble=req.preamble,
         output_dir=output_dir,
     )


### PR DESCRIPTION
## Summary
- `ConvertRequest` hardcoded `max_retries=3` and `dpi=300`, which always overrode env var values from `Settings` — so `NOTES2LATEX_MAX_RETRIES` in `.env` had no effect when using the web UI
- Made these fields optional (`None`) so env vars take effect when no explicit value is provided by the frontend
- Added `temperature` and `max_tokens` as optional overridable fields too
- Added a collapsible "Advanced" section to the Settings page exposing max retries, DPI, temperature, and max tokens — leaving them blank uses server/env defaults

Closes #2

## Test plan
- [ ] Set `NOTES2LATEX_MAX_RETRIES=1` in `.env`, run a conversion via web UI, confirm only 1 retry attempt per page
- [ ] Set `NOTES2LATEX_DPI=150` in `.env`, confirm lower-res rasterization
- [ ] Set max retries to `2` in Settings > Advanced, confirm it overrides the env var
- [ ] Leave all Advanced fields blank, confirm server defaults are used
- [ ] All existing tests pass